### PR TITLE
v4l2: Reuse right buffer index when dmabuf import mode

### DIFF
--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2allocator.c
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2allocator.c
@@ -357,6 +357,8 @@ gst_v4l2_allocator_release (GstV4l2Allocator * allocator, GstV4l2Memory * mem)
 
   switch (allocator->memory) {
     case V4L2_MEMORY_DMABUF:
+      if (V4L2_TYPE_IS_CAPTURE(allocator->obj->type) && (allocator->obj->mode == GST_V4L2_IO_DMABUF_IMPORT))
+        break;
       close (mem->dmafd);
       mem->dmafd = -1;
       break;
@@ -1023,6 +1025,93 @@ gst_v4l2_allocator_alloc_dmabufin (GstV4l2Allocator * allocator)
   return group;
 }
 
+GstV4l2MemoryGroup *
+gst_v4l2_allocator_alloc_dmabufin_capture (GstV4l2Allocator * allocator,
+    GstAllocator * dmabuf_allocator, GstBuffer* downstream_buffer)
+{
+  GstV4l2Object *obj = allocator->obj;
+  GstV4l2MemoryGroup *group;
+  gint i;
+
+  g_return_val_if_fail (allocator->memory == V4L2_MEMORY_DMABUF, NULL);
+
+  group = gst_v4l2_allocator_alloc (allocator);
+
+  if (group == NULL)
+    return NULL;
+
+  for (i = 0; i < group->n_mem; i++) {
+    GstV4l2Memory *mem;
+    GstMemory *dma_mem;
+    gsize size, offset, maxsize;
+
+
+    if (group->mem[i] == NULL) {
+      dma_mem = gst_buffer_peek_memory (downstream_buffer, i);
+      int downstream_fd = gst_dmabuf_memory_get_fd (dma_mem);
+      int dup_fd = dup (downstream_fd);
+
+      GST_LOG_OBJECT (allocator, "import DMABUF fd %d into fd %i plane %d",
+          downstream_fd, dup_fd, i);
+
+      group->planes[i].m.fd = dup_fd;
+      group->planes[i].length = dma_mem->size;
+      group->planes[i].data_offset = dma_mem->offset;
+
+      group->mem[i] = (GstMemory *) _v4l2mem_new (0, GST_ALLOCATOR (allocator),
+          NULL, group->planes[i].length, 0, group->planes[i].data_offset,
+          group->planes[i].length - group->planes[i].data_offset, i, NULL,
+          dup_fd, group);
+    } else {
+      /* Take back the allocator reference */
+      gst_object_ref (allocator);
+    }
+
+    group->mems_allocated++;
+
+    g_assert (gst_is_v4l2_memory (group->mem[i]));
+    mem = (GstV4l2Memory *) group->mem[i];
+
+    dma_mem = gst_fd_allocator_alloc (dmabuf_allocator, mem->dmafd,
+        group->planes[i].length, GST_FD_MEMORY_FLAG_DONT_CLOSE);
+    gst_memory_resize (dma_mem, group->planes[i].data_offset,
+        group->planes[i].length - group->planes[i].data_offset);
+
+    gst_mini_object_set_qdata (GST_MINI_OBJECT (dma_mem),
+        GST_V4L2_MEMORY_QUARK, mem, (GDestroyNotify) gst_memory_unref);
+
+
+    group->mem[i] = dma_mem;
+  }
+
+  if (!V4L2_TYPE_IS_MULTIPLANAR (obj->type)) {
+    group->buffer.bytesused = group->planes[0].bytesused;
+    group->buffer.length = group->planes[0].length;
+    group->buffer.m.fd = group->planes[0].m.fd;
+
+    /* FIXME Check if data_offset > 0 and fail for non-multi-planar */
+    g_assert (group->planes[0].data_offset == 0);
+  } else {
+    group->buffer.length = group->n_mem;
+  }
+
+  gst_v4l2_allocator_reset_size (allocator, group);
+
+  return group;
+
+expbuf_failed:
+  {
+    GST_ERROR_OBJECT (allocator, "Failed to export DMABUF: %s",
+        g_strerror (errno));
+    goto cleanup;
+  }
+cleanup:
+  {
+    _cleanup_failed_alloc (allocator, group);
+    return NULL;
+  }
+}
+
 static void
 gst_v4l2_allocator_clear_userptr (GstV4l2Allocator * allocator,
     GstV4l2MemoryGroup * group)
@@ -1455,6 +1544,9 @@ gst_v4l2_allocator_reset_group (GstV4l2Allocator * allocator,
       gst_v4l2_allocator_clear_userptr (allocator, group);
       break;
     case V4L2_MEMORY_DMABUF:
+      if (V4L2_TYPE_IS_CAPTURE(allocator->obj->type) && (allocator->obj->mode == GST_V4L2_IO_DMABUF_IMPORT)) {
+        break;
+      }
       gst_v4l2_allocator_clear_dmabufin (allocator, group);
       break;
     case V4L2_MEMORY_MMAP:

--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2allocator.h
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2allocator.h
@@ -137,6 +137,9 @@ GstV4l2MemoryGroup*  gst_v4l2_allocator_alloc_dmabuf   (GstV4l2Allocator * alloc
 
 GstV4l2MemoryGroup * gst_v4l2_allocator_alloc_dmabufin (GstV4l2Allocator * allocator);
 
+GstV4l2MemoryGroup * gst_v4l2_allocator_alloc_dmabufin_capture (GstV4l2Allocator * allocator,
+       	    GstAllocator * dmabuf_allocator, GstBuffer* downstream_buffer);
+
 GstV4l2MemoryGroup * gst_v4l2_allocator_alloc_userptr  (GstV4l2Allocator * allocator);
 
 gboolean             gst_v4l2_allocator_import_dmabuf  (GstV4l2Allocator * allocator,

--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2bufferpool.c
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2bufferpool.c
@@ -456,6 +456,7 @@ gst_v4l2_buffer_pool_alloc_buffer (GstBufferPool * bpool, GstBuffer ** buffer,
   GstBuffer *newbuf = NULL;
   GstV4l2Object *obj;
   GstVideoInfo *info;
+  GstBuffer *downstream_buffer = NULL;
 
   obj = pool->obj;
   info = &obj->info;
@@ -476,7 +477,16 @@ gst_v4l2_buffer_pool_alloc_buffer (GstBufferPool * bpool, GstBuffer ** buffer,
       group = gst_v4l2_allocator_alloc_userptr (pool->vallocator);
       break;
     case GST_V4L2_IO_DMABUF_IMPORT:
-      group = gst_v4l2_allocator_alloc_dmabufin (pool->vallocator);
+      if (V4L2_TYPE_IS_OUTPUT(obj->type))
+        group = gst_v4l2_allocator_alloc_dmabufin (pool->vallocator);
+      else {
+        gst_buffer_pool_acquire_buffer (pool->other_pool, &downstream_buffer, NULL);
+        group = gst_v4l2_allocator_alloc_dmabufin_capture (pool->vallocator, pool->allocator, downstream_buffer);
+        if (group == NULL) {
+          gst_buffer_unref (downstream_buffer);
+          GST_DEBUG_OBJECT (pool, "fail to create buf");
+        }
+      }    
       break;
     default:
       newbuf = NULL;
@@ -511,6 +521,11 @@ gst_v4l2_buffer_pool_alloc_buffer (GstBufferPool * bpool, GstBuffer ** buffer,
   }
 
   *buffer = newbuf;
+
+  if (downstream_buffer) {
+    gst_mini_object_set_qdata (GST_MINI_OBJECT (newbuf), GST_V4L2_IMPORT_QUARK,
+        downstream_buffer, (GDestroyNotify) gst_buffer_unref);
+  }
 
   return GST_FLOW_OK;
 
@@ -566,6 +581,7 @@ gst_v4l2_buffer_pool_set_config (GstBufferPool * bpool, GstStructure * config)
           GST_V4L2_ALLOCATOR_CAN_ALLOCATE (pool->vallocator, USERPTR);
       break;
     case GST_V4L2_IO_DMABUF_IMPORT:
+      pool->allocator = gst_dmabuf_allocator_new ();
       can_allocate = GST_V4L2_ALLOCATOR_CAN_ALLOCATE (pool->vallocator, DMABUF);
       break;
     case GST_V4L2_IO_RW:
@@ -1741,7 +1757,6 @@ gst_v4l2_buffer_pool_complete_release_buffer (GstBufferPool * bpool,
         case GST_V4L2_IO_DMABUF:
         case GST_V4L2_IO_MMAP:
         case GST_V4L2_IO_USERPTR:
-        case GST_V4L2_IO_DMABUF_IMPORT:
         {
           GstV4l2MemoryGroup *group;
           if (gst_v4l2_is_buffer_valid (buffer, &group)) {
@@ -1764,6 +1779,22 @@ gst_v4l2_buffer_pool_complete_release_buffer (GstBufferPool * bpool,
             if (ret != GST_FLOW_OK ||
                 gst_v4l2_buffer_pool_qbuf (pool, buffer, group,
                     NULL) != GST_FLOW_OK)
+              pclass->release_buffer (bpool, buffer);
+          } else {
+            /* Simply release invalid/modified buffer, the allocator will
+             * give it back later */
+            GST_BUFFER_FLAG_SET (buffer, GST_BUFFER_FLAG_TAG_MEMORY);
+            pclass->release_buffer (bpool, buffer);
+          }
+          break;
+        }
+        case GST_V4L2_IO_DMABUF_IMPORT:
+        {
+          GstV4l2MemoryGroup *group;
+          if (gst_v4l2_is_buffer_valid (buffer, &group)) {
+            GstFlowReturn ret = GST_FLOW_OK;
+            if (ret != GST_FLOW_OK ||
+                gst_v4l2_buffer_pool_qbuf (pool, buffer, group, NULL) != GST_FLOW_OK)
               pclass->release_buffer (bpool, buffer);
           } else {
             /* Simply release invalid/modified buffer, the allocator will
@@ -2221,17 +2252,6 @@ gst_v4l2_buffer_pool_process (GstV4l2BufferPool * pool, GstBuffer ** buf,
 
         case GST_V4L2_IO_DMABUF_IMPORT:
         {
-          GstBuffer *tmp;
-
-          /* Replace our buffer with downstream allocated buffer */
-          tmp = gst_mini_object_steal_qdata (GST_MINI_OBJECT (*buf),
-              GST_V4L2_IMPORT_QUARK);
-
-          gst_buffer_copy_into (tmp, *buf,
-              GST_BUFFER_COPY_FLAGS | GST_BUFFER_COPY_TIMESTAMPS, 0, -1);
-
-          gst_buffer_replace (buf, tmp);
-          gst_buffer_unref (tmp);
           break;
         }
 

--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2object.c
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2object.c
@@ -5210,7 +5210,13 @@ gst_v4l2_object_decide_allocation (GstV4l2Object * obj, GstQuery * query)
       own_min += 2;
       gst_v4l2_buffer_pool_copy_at_threshold (GST_V4L2_BUFFER_POOL (pool),
           TRUE);
-    } else {
+    }else if (V4L2_TYPE_IS_CAPTURE(obj->type) && (obj->mode == GST_V4L2_IO_DMABUF_IMPORT)) {
+      // since we reuse right index, so let's keep buffer number of downstream pool same with v4l2buffer pool
+      GST_DEBUG_OBJECT (pool, "got min: %d own_min: %d max: %d min_buffers:%d", min, own_min, max, obj->min_buffers);
+      own_min = (obj->min_buffers) + min + 1;
+      min = own_min;
+    }
+    else {
       gst_v4l2_buffer_pool_copy_at_threshold (GST_V4L2_BUFFER_POOL (pool),
           FALSE);
     }


### PR DESCRIPTION
The changes are made to address writing data at dma buf specified offset.
In import mode v4l2 tries to acquire buffer from downstream pool, and if downstream fails to provide the dma buffer It creates Its own buffer, which doesnt persist the offset information provided from downstream element.
